### PR TITLE
Re-enable search.

### DIFF
--- a/sphinx_catalystcloud_theme/search.html
+++ b/sphinx_catalystcloud_theme/search.html
@@ -10,6 +10,7 @@
 {%- extends "layout.html" %}
 {% set title = _('Search') %}
 {% set script_files = script_files + ['_static/searchtools.js'] %}
+{% set script_files = script_files + ['_static/language_data.js'] %}
 {% block extrahead %}
   <script type="text/javascript">
     jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });


### PR DESCRIPTION
Ref Sphinx upstream change:
https://github.com/sphinx-doc/sphinx/commit/f5289bb69993d2b1f83a509f56e418fcd5d00b87

This fixes search on our use with Sphinx 4.1.2, but is probably relevant to all versions starting with 3.4.0.